### PR TITLE
Backend: Limit number of stacks a user can create

### DIFF
--- a/controllers/stacks.js
+++ b/controllers/stacks.js
@@ -15,7 +15,7 @@ async function newStack(req, res) {
 		res.render("stacks/new", { title: "Enter a New Stack" });
 	} else {
 		//render an error page
-		res.render("error", { title: "Something Went Wrong" });
+		res.render("addStacksError", { title: "Something Went Wrong" });
 	}
 }
 

--- a/views/addStacksError.ejs
+++ b/views/addStacksError.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<%- include('./partials/head') %>
+<body>
+    <%- include('./partials/header') %>
+
+    <!-- style this h2 -->
+    <h2>Oh No! You can only have 5 stacks.</h2>
+    <h3>To add another stack, you must delete one first.</h3>
+    <img src="../images/logo.png" alt="an image of the logo for Stacks. A round yellow logo with 3 white rectangles stacked horizontally with the word 'Stacks' above">
+    <p>Try again later or <a href="/">go back home</a></p>
+    <%- include('./partials/footer') %> 
+</body>
+</html> 


### PR DESCRIPTION
[✅] Your title is short and informative
[✅] Prefixed with corresponding ticket/story id (e.g. from Jira, Trello, GitHub issue, etc.) (if applicable)
[✅] Prefixed also with [Frontend], [Backend], [DevOps], etc.
[✅] Written in imperative present tense
[✅] Double checked that there are no PRs currently open and waiting to be merged
 -----------------------------------------------------
[✅] What is the feature/issue addressed?
A user can only create five stacks.
[✅] How did you implement the solution?
The newStack function now checks how many stacks a user currently has. If they have less than five stacks, the stacks/new page will render. If they have five stacks, an error page will render.
[✅] Does it impact any other area of the project?
I discovered and corrected a bug within the deleteStack function. Stacks are now deleted from MongoDB as well as from the user's stacks array.
[✅] Any changes in the UI (Screenshots)?
A custom error page was added. It tells the user they can only have five stacks.
[✅] How to test the feature (A test scenario or any new setup)?
You can test manually via the browser & doublecheck the results in MongoDB.