### PR TITLE
Backend: Fix deleteBook & deleteStack Bugs

### DIFF
--- a/controllers/stacks.js
+++ b/controllers/stacks.js
@@ -99,20 +99,11 @@ async function deleteStack(req, res) {
 	//find current user
 	const user = await User.findById(req.user._id);
 	//find index of stack that has been deleted
-	const idx = user.stacks.findIndex((stack) => stack === req.params.id);
-	//create a new stack to hold all stacks, except the one that has been deleted
-	//splice could not be used as it overwrites the array & changed the array items object types
-	const newStacks = [];
-	//iterate over user's current stack array
-	for (let i = 0; i < user.stacks.length; i++) {
-		//if the current element's index does not equal the index that needs to be deleted
-		if (i !== idx) {
-			//add current element to new stacks array
-			newStacks.push(user.stacks[i]);
-		}
-	}
-	//change user's stack to the new stacks array
-	user.stacks = newStacks;
+	const idx = user.stacks.findIndex(
+		(stack) => stack.toString() === req.params.id
+	);
+	//delete the stack from the user's stacks
+	user.stacks.splice(idx, 1);
 	//save user via Mongoose
 	await user.save();
 	//render stacks index page
@@ -124,7 +115,9 @@ async function deleteBook(req, res) {
 	//find current stack
 	const stack = await Stack.findById(req.params.id);
 	//find index of book that will be deleted
-	const idx = stack.books.findIndex((book) => book === req.params.bookId);
+	const idx = stack.books.findIndex(
+		(book) => book.toString() === req.params.bookId
+	);
 	//remove book from stack's book array
 	stack.books.splice(idx, 1);
 	//save stack via Mongoose

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -267,7 +267,7 @@ table{
 }
 
 #add-stack-table{
-    width: 22.5vmin;
+    width: 29vmin;
 }
 
 th, td{


### PR DESCRIPTION
[✅] Your title is short and informative
[✅] Prefixed with corresponding ticket/story id (e.g. from Jira, Trello, GitHub issue, etc.) (if applicable)
[✅] Prefixed also with [Frontend], [Backend], [DevOps], etc.
[✅] Written in imperative present tense
[✅] Double checked that there are no PRs currently open and waiting to be merged
 -----------------------------------------------------
[✅] What is the feature/issue addressed?
-Clicking the trashcan button next to a book will now delete that book.
-Deleting a stack now properly deletes it from a user's stacks in addition to the database.
[✅] How did you implement the solution?
Using the method .toString() and the array method splice.
[✅] Does it impact any other area of the project?
No.
[✅] Any changes in the UI (Screenshots)?
N/A
[✅] How to test the feature (A test scenario or any new setup)?
Test manually via browser & doublecheck results in MongoDB.